### PR TITLE
Switch linter to Ruff

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-
     steps:
     - uses: actions/checkout@v3
       with:
@@ -24,10 +23,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: make develop
-    - name: Lint with flake8
+      run: make install
+    - name: Code Linting
       run: make lint
-    - name: Test with pytest
+    - name: Code Testing
       run: make test-report
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master

--- a/Makefile
+++ b/Makefile
@@ -4,20 +4,20 @@ help:  # Displays the help menu with all the targets
 apidocs:  # Creates API documentation for RTDs
 	@sphinx-apidoc -f -o docs cruds/
 
+install:  update-pip  # Installs all requirements and testing requirements
+	@python -m pip install -e '.[develop]'
+
 test:  # Perform unit testing on the source code
 	@python -m pytest
 
 test-report:  # Perform unit testing on the source code with a coverage report
 	@python -m pytest --cov-report=xml
 
-lint:  # Perform quality checks on the source code
-	# stop the build if there are Python syntax errors or undefined names
-	@python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-	# exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-	@python -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+lint:  # Quality checks on the source code (Doesn't change code)
+	@python -m ruff check --diff src/
 
-develop:  update-pip  # Installs all requirements and testing requirements
-	@python -m pip install -e '.[develop]'
+format:  # Check the format of source code  (Doesn't change code)
+	@python -m ruff format --diff src/
 
 update-pip:  # Updates the version of pip
 	@python -m pip install --upgrade pip
@@ -32,4 +32,4 @@ clean:  # Removes built Python Packages and cached byte code
 		echo "clean completed"
 
 .DEFAULT_GOAL := help
-.PHONY: docs test lint develop clean help
+.PHONY: help apidocs install test test-report lint format update-pip uninstall clean

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,16 +4,17 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+
+sys.path.insert(0, os.path.abspath("../src"))
 
 import cruds
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'CRUDs'
-copyright = '2024, John Brandborg'
-author = 'John Brandborg'
+project = "CRUDs"
+copyright = "2024, John Brandborg"
+author = "John Brandborg"
 version = cruds.__version__
 release = cruds.__version__
 
@@ -21,17 +22,17 @@ release = cruds.__version__
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.todo',
-    'sphinx.ext.viewcode',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.todo",
+    "sphinx.ext.viewcode",
 ]
 
-templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 todo_include_todos = True
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
-html_static_path = ['_static']
+html_theme = "alabaster"
+html_static_path = ["_static"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,77 @@
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.8
+target-version = "py38"
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ where = src
 
 [options.extras_require]
 develop =
-    flake8
+    ruff
     pytest
     pytest-cov
 
@@ -80,6 +80,3 @@ exclude_lines =
     ^if __name__ ==
     ^\s*except KeyboardInterrupt
     @abc.abstractmethod
-
-[flake8]
-per-file-ignores = __init__.py:F401

--- a/src/cruds/__init__.py
+++ b/src/cruds/__init__.py
@@ -29,3 +29,5 @@ from .core import Client
 
 __author__: str = "John Brandborg"
 __version__: str = "1.3.0"
+
+__all__: list = ["Client", "auth"]

--- a/tests/interfaces/test_planhat.py
+++ b/tests/interfaces/test_planhat.py
@@ -5,7 +5,6 @@ Tests for Planhat interface logic in CRUDs
 from collections.abc import Generator
 from copy import deepcopy
 import json
-from re import I
 from unittest.mock import MagicMock, Mock
 
 import pytest
@@ -371,7 +370,7 @@ def test_Model_get_lean_list(planhat_model):
     planhat_model.get_lean_list()
 
     planhat_model._owner.client.read.assert_called_with(
-        f"leancompanies",
+        "leancompanies",
         params={},
     )
 
@@ -384,7 +383,7 @@ def test_Model_get_lean_list_externl_id(planhat_model):
     planhat_model.get_lean_list(external_id="chevron")
 
     planhat_model._owner.client.read.assert_called_with(
-        f"leancompanies",
+        "leancompanies",
         params={"externalId": "chevron"},
     )
 
@@ -396,7 +395,7 @@ def test_Model_get_lean_list_source_id(planhat_model):
     planhat_model.get_lean_list(source_id="0012000001UchdsAAB")
 
     planhat_model._owner.client.read.assert_called_with(
-        f"leancompanies",
+        "leancompanies",
         params={"sourceId": "0012000001UchdsAAB"},
     )
 
@@ -407,7 +406,7 @@ def test_Model_get_lean_list_status_list(planhat_model):
     """
     planhat_model.get_lean_list(status=["lost", "prospect"])
     planhat_model._owner.client.read.assert_called_with(
-        f"leancompanies",
+        "leancompanies",
         params={"status": ["lost", "prospect"]},
     )
 
@@ -418,7 +417,7 @@ def test_Model_get_lean_list_status_string(planhat_model):
     """
     planhat_model.get_lean_list(status="lost, prospect")
     planhat_model._owner.client.read.assert_called_with(
-        f"leancompanies",
+        "leancompanies",
         params={"status": ["lost", "prospect"]},
     )
 


### PR DESCRIPTION
### Purpose
Move the project to Ruff instead of Flake8.

### Approach
Adjust the development workflow to install and run Ruff check.  No Ruff formatting requirements.
